### PR TITLE
feat: edit initial value of best time, inf to 999.9

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/section_timer/src/section_timer_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/section_timer/src/section_timer_node.cpp
@@ -49,7 +49,7 @@ public:
 
     // セクションタイム配列とベストタイム差分配列を初期化（13要素: 12セクション + 1ラップタイム）
     section_times_.resize(sections_.size() + 1, 0.0);
-    best_times_.resize(sections_.size(), std::numeric_limits<float>::infinity());
+    best_times_.resize(sections_.size(), 999.9);
     best_times_diff_.resize(sections_.size() + 1, 0.0);  // 最初は全て0.0で初期化
   }
 


### PR DESCRIPTION
セクションタイマーのBestラップとの差をPubするさいに、１週目はinfと表示していましたが、999.9に設定しました。
ほぼ確認はいりませんが、下のコマンドで確認できます。１週目は900秒代が表示されるようになります。
`
ros2 topic echo /section/section_timer_difference_from_best
`